### PR TITLE
llama: LLAMA_GRAPH_TIMING, where the CPU time of a decode goes

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1336,7 +1336,12 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
     // in order to correctly reuse a graph, it's full topology has to be uniquely determined by these parameters
     const auto gparams = graph_params(res, ubatch, mctx, gtype);
 
+    // LLAMA_GRAPH_TIMING=1: log where the CPU time of a decode goes (build, alloc, inputs)
+    static const bool graph_timing = getenv("LLAMA_GRAPH_TIMING") && atoi(getenv("LLAMA_GRAPH_TIMING")) != 0;
+    int64_t t_build = 0, t_alloc = 0, t_inputs = 0;
+    bool reused = false;
     if (!graph_reuse_disable && res->can_reuse(gparams)) {
+        reused = true;
         //LLAMA_LOG_DEBUG("%s: reusing previous graph\n", __func__);
 
         // with pipeline parallelism, the previous graph_compute_async may still be running
@@ -1353,11 +1358,11 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
         ggml_backend_sched_reset(sched.get());
         ggml_backend_sched_set_eval_callback(sched.get(), cparams.cb_eval, cparams.cb_eval_user_data);
 
-        //const auto t_start_us = ggml_time_us();
+        const auto t_build_us = ggml_time_us();
 
         gf = model.build_graph(gparams);
 
-        //LLAMA_LOG_INFO("graph build time: %.3f ms\n", (ggml_time_us() - t_start_us)/1000.0);
+        t_build = ggml_time_us() - t_build_us;
 
         if (!gf) {
             LLAMA_LOG_ERROR("%s: failed to initialize graph\n", __func__);
@@ -1365,21 +1370,28 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
             return nullptr;
         }
 
+        const auto t_alloc_us = ggml_time_us();
         if (!ggml_backend_sched_alloc_graph(sched.get(), gf)) {
             LLAMA_LOG_ERROR("%s: failed to allocate graph\n", __func__);
             ret = GGML_STATUS_ALLOC_FAILED;
             return nullptr;
         }
+        t_alloc = ggml_time_us() - t_alloc_us;
     }
 
     // set the input data for the input tensors
     {
-        //const auto t_start_us = ggml_time_us();
+        const auto t_inputs_us = ggml_time_us();
 
         // FIXME this call causes a crash if any model inputs were not used in the graph and were therefore not allocated
         res->set_inputs(&ubatch);
 
-        //LLAMA_LOG_INFO("graph set inputs time: %.3f ms\n", (ggml_time_us() - t_start_us)/1000.0);
+        t_inputs = ggml_time_us() - t_inputs_us;
+        if (graph_timing) {
+            LLAMA_LOG_WARN("graph-timing: n_tokens=%3u gtype=%d reused=%d build=%.2f alloc=%.2f inputs=%.2f ms nodes=%d\n",
+                           ubatch.n_tokens, (int) gtype, (int) reused, t_build/1000.0, t_alloc/1000.0, t_inputs/1000.0,
+                           ggml_graph_n_nodes(res->get_gf()));
+        }
     }
 
     const auto status = graph_compute(res->get_gf(), ubatch.n_tokens > 1);


### PR DESCRIPTION
What remains of [LaurentZuijdwijk/llama.cpp#3](https://github.com/LaurentZuijdwijk/llama.cpp/pull/3) after the qwen4exp merge: the diagnostic, not the optimisation.

That PR added `can_reuse()` to the QSA and PLE graph inputs. ggml-org#27742 landed its own implementations of both (`src/models/qwen4exp.cpp:428` for QSA, `:966` for the PLE rows), so the optimisation is already in this tree and **the 49.6 → 46.7 ms figure from the original PR belongs to it, not to this change.** Nothing here claims a speedup.

The two implementations are not identical, and neither is a superset of the other — worth someone's eye, but it is a separate question from this PR:

| | upstream | ours (not proposed here) |
|---|---|---|
| `bias->ne[0]` | `blk_bias ? n_blocks : n_kv` | `n_kv` only |
| `blk_cells->ne[1]`, `bias->ne[2]` | not checked | checked against `n_stream` |
| `n_stream > 0` | not guarded | guarded |

The PLE-rows override is equivalent modulo a `rows != nullptr` guard.

### What this PR is

The instrument that made the problem visible. The qwen4exp graph is ~8,000 nodes, and a graph rebuilt and reallocated every decode shows up only as an unexplained gap between the sampling and eval timings the server already reports. This logs build / alloc / set_inputs time, the reuse decision and the node count for each decode, at this format:

```
graph-timing: n_tokens=%3u gtype=%d reused=%d build=%.2f alloc=%.2f inputs=%.2f ms nodes=%d
```

Off unless `LLAMA_GRAPH_TIMING=1`. It replaces three commented-out timing blocks already sitting in `build_graph` for the same purpose, so the net addition is small: 16 lines added, 4 removed, one file.

Build-verified only — no runtime output is quoted here because none was captured on this base.
