### PR TITLE
speculative: keep DFlash draft blocks the same width across sequences

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -210,6 +210,14 @@ struct common_speculative_impl {
         }
     }
 
+    // record the width a sequence was actually drafted at, when the caller had to
+    // override the per-sequence choice (see the DFlash/DSpark batch below)
+    void set_last_draft(llama_seq_id seq_id, int32_t n) {
+        if (seq_id >= 0 && (size_t) seq_id < n_last_draft.size()) {
+            n_last_draft[seq_id] = n;
+        }
+    }
+
     // effective draft length for this step, never above the configured n_max
     int32_t adaptive_n_draft(llama_seq_id seq_id, int32_t n_cfg, int32_t n_min) {
         if (!adaptive_n || seq_id < 0 || (size_t) seq_id >= acc_ema.size()) {
@@ -1283,6 +1291,44 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
         std::vector<int32_t> i_block_beg(n_seq, -1);
         std::vector<int32_t> n_block    (n_seq,  0);
 
+        // DFlash decodes the whole block in one pass, so a shorter block does not save
+        // draft time -- but it does shrink the target's verification batch, which is
+        // where the cost actually is.
+        //
+        // The block width has to be the same for every sequence in this batch. All the
+        // blocks go into one decode, and the draft graph reshapes those tokens into
+        // [block_size, n_seqs] -- build_dflash2_conv and the DSpark markov head both
+        // assert n_tokens % n_seqs_unq == 0. Per-sequence widths break that: with an
+        // equal ubatch split the longer block is silently cut across two ubatches, so
+        // its tail is convolved as a block of its own and drafts from a truncated
+        // window; with a simple split it trips the assert and takes the server down.
+        // So size the batch once, from the sequence with the highest measured
+        // acceptance: no sequence drafts shorter than its own estimate, and the extra
+        // positions a colder sequence receives are just rejected at verification.
+        int32_t n_draft_batch = params.n_max;
+
+        if (adaptive_n) {
+            n_draft_batch = 0;
+
+            for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
+                if (!dparams[seq_id].drafting) {
+                    continue;
+                }
+
+                n_draft_batch = std::max(n_draft_batch, adaptive_n_draft(seq_id, params.n_max, params.n_min));
+            }
+
+            if (n_draft_batch == 0) {
+                return;
+            }
+
+            for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
+                if (dparams[seq_id].drafting) {
+                    set_last_draft(seq_id, n_draft_batch);
+                }
+            }
+        }
+
         for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
             auto & dp = dparams[seq_id];
             if (!dp.drafting) {
@@ -1293,10 +1339,7 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
 
             const int32_t n = (int32_t) dp.n_past;
 
-            // DFlash decodes the whole block in one pass, so a shorter block does
-            // not save draft time -- but it does shrink the target's verification
-            // batch, which is where the cost actually is.
-            const int32_t n_draft = adaptive_n_draft(seq_id, params.n_max, params.n_min);
+            const int32_t n_draft = n_draft_batch;
 
             const int32_t n_block_tokens = n_draft + (is_dspark && sample_from_anchor ? 0 : 1);
             i_block_beg[seq_id] = batch.n_tokens;


### PR DESCRIPTION
`--spec-draft-adaptive` (#1) sizes each draft from that sequence's measured acceptance. The DFlash/DSpark implementation packs every drafting sequence's noise block into one decode, and the draft graph reshapes those tokens into `[block_size, n_seqs]` - `build_dflash2_conv` and the DSpark markov head both assert `n_tokens % n_seqs_unq == 0`.

So the width has to be the same for every sequence in that batch. With two slots drafting off different EMAs it isn't, and what happens next depends on how the draft model splits the batch into ubatches:

- **equal split** (what the Qwen3.8-27B DFlash2 drafter takes): the assert never fires. `split_equal` equalises the counts by cutting the longer block across two ubatches, so its tail is convolved as a block of its own, from a truncated window. Output stays correct - the target verifies every drafted token - but the drafts come out of the wrong convolution and acceptance drops hard.
- **simple split**: the ragged batch reaches the graph intact and the assert takes the server down.

### Measured

Radeon 8060S (RADV, Mesa 26.3-dev), `Qwen3.8-27B-UD-Q4_K_XL` target + `Qwen3.8-27B-DFlash2-Q4_K_M` drafter, `-fa 1 -c 8192 -np 2 --spec-type draft-dflash --spec-draft-n-max 7 --spec-draft-adaptive`. Two concurrent requests, greedy, thinking off: one repeating a fixed sentence ten times (predictable, 280 tokens), one writing free prose (300 tokens). Counterbalanced W-B-A-A-B over five server launches, warmup discarded, one request pair per launch.

| | ragged draft rounds | repeat req: acceptance / mean len / t/s | prose req: acceptance / mean len / t/s |
|---|---|---|---|
| before, run 1 | 62 / 140 | 0.661 / 3.15 / 15.02 | 0.480 / 2.14 / 12.45 |
| before, run 2 | 106 / 204 | 0.562 / 2.09 / 10.72 | 0.323 / 1.47 / 8.83 |
| after, run 1  | 0 / 134   | 0.996 / 7.57 / 29.01 | 0.344 / 2.22 / 14.52 |
| after, run 2  | 0 / 138   | 0.996 / 7.57 / 28.71 | 0.340 / 2.18 / 14.48 |

(the ragged-round counts came from a temporary log line, not part of this patch.)

The predictable request goes from 2.09-3.15 accepted tokens per draft to 7.57 - 243 of 244 drafted tokens accepted - and 1.9-2.7x the throughput. The prose request, now sized up to the other slot's width, still gains 16-64%. The before-arm spread is part of the symptom: how badly a block gets cut depends on how the two slots happen to line up.

Single stream is unaffected either way - one drafting sequence is trivially uniform.

### The fix

Size the batch once, from the sequence with the highest measured acceptance, and record that width as the one each sequence was drafted at so the EMA keeps learning from what was actually issued. No sequence drafts shorter than its own estimate; the extra positions a colder sequence receives are rejected at verification, which costs verify width only - DFlash decodes the whole block in one pass either way.

Grouping sequences by width and issuing one decode per distinct width would preserve per-sequence adaptivity exactly, at up to n_seq decodes per round. That looked like the wrong trade for the amount of divergence actually seen, but happy to do it that way instead.

Unrelated, noticed while reading the controller: `update_acc_ema` compares `n_accepted` against the width that was *requested*, not the number of tokens the draft actually produced. A draft cut short by `p_min` (or by the DFlash2 selector's confidence break) then reads as a partial accept even when every token it produced was accepted, and the EMA ratchets down. Only reachable with p_min > 0, so it is not in this patch.
