### PR TITLE
qwen4exp: fix --ngram-on-disk, which crashes on every model

### DIFF
--- a/src/models/qwen4exp.cpp
+++ b/src/models/qwen4exp.cpp
@@ -1069,17 +1069,14 @@ void llm_graph_input_ple::set_input(const llama_ubatch * ubatch) {
     }
 
     if (pmodel.ple_disk) {
-        // idx is head-major and head-local; the reader wants one global row per (token, head)
-        // in token-major order, which is the layout the per-head gather + concat produces.
+        // idx is already exactly what the reader wants: one global row per (token, head),
+        // token-major, with ple_head_offsets folded in by the loop above. The previous
+        // version read it head-major and added the offset a second time, which is only
+        // correct for a table split per head -- on a joined per_layer_token_embd it walks
+        // past the end (rows beyond ple_rows) and gather() aborts.
         GGML_ASSERT(embd != nullptr && rows == nullptr);
-        rows_global.resize(idx.size());
-        for (int64_t i = 0; i < n_tokens; ++i) {
-            for (int64_t h = 0; h < n_heads; ++h) {
-                rows_global[i*n_heads + h] = (int32_t) (idx[h*n_tokens + i] + (int64_t) hp.ple_head_offsets[h]);
-            }
-        }
-        embd_buf.resize(rows_global.size() * (size_t) hp.ple_head_dim);
-        pmodel.ple_disk->gather(rows_global.data(), rows_global.size(), embd_buf.data());
+        embd_buf.resize(idx.size() * (size_t) hp.ple_head_dim);
+        pmodel.ple_disk->gather(idx.data(), idx.size(), embd_buf.data());
         ggml_backend_tensor_set(embd, embd_buf.data(), 0, embd_buf.size() * sizeof(float));
         return;
     }

--- a/src/models/qwen4exp.cpp
+++ b/src/models/qwen4exp.cpp
@@ -990,7 +990,19 @@ public:
 
     bool can_reuse(const llm_graph_params & params) override {
         mctx = static_cast<const llama_memory_hybrid_idx_context *>(params.mctx)->get_attn();
-        return rows->ne[0] == (int64_t) pmodel.hparams.ple_n_heads * params.ubatch.n_tokens;
+
+        const int64_t n_want = (int64_t) pmodel.hparams.ple_n_heads * params.ubatch.n_tokens;
+
+        // exactly one of the two is built: `rows` when the table is a tensor and the
+        // graph does the get_rows, `embd` when --ngram-on-disk gathered it in set_input.
+        // Dereferencing `rows` unconditionally segfaults on every on-disk decode.
+        if (rows) {
+            return rows->ne[0] == n_want;      // I32 [n_heads*n_tokens]
+        }
+        if (embd) {
+            return embd->ne[1] == n_want;      // F32 [ple_head_dim, n_heads*n_tokens]
+        }
+        return false;
     }
 
     ggml_tensor * rows = nullptr;   // I32 [ple_n_heads * n_tokens]


### PR DESCRIPTION
`--ngram-on-disk` (542ff665) cannot serve any model on this tree. Two independent
bugs, both introduced when the feature was ported here from
`LaurentZuijdwijk/llama.cpp@vulkan/qwen4exp-rocmfpx`, where the surrounding code
holds different invariants.

### 1. `ple_head_offsets` applied twice — aborts at load

`llm_graph_input_ple::set_input()` builds `idx` **token-major and head-global** — it
folds `ple_head_offsets` in when it hashes each n-gram:

```cpp
idx[i * n_heads + h_i] = mixed % hp.ple_head_vocab_sizes[h_i] + hp.ple_head_offsets[h_i];
```

The on-disk path then reads it back **head-major** and adds the offset a **second**
time:

```cpp
// "idx is head-major and head-local"   <- no longer true on this tree
rows_global[i*n_heads + h] = idx[h*n_tokens + i] + hp.ple_head_offsets[h];
```

Both are correct on Laurent's branch, where the table is stored one tensor per head
and `idx` really is head-local. Here it walks off the end:

```
llama_ple_disk: row index out of range (768795..611212235 of 320001536 rows)
```

`gather()` already wants token-major global rows and writes `dst` in input order, so
`idx` can go straight through.

### 2. `can_reuse()` dereferences a null `rows` — segfaults on first decode

`llm_graph_input_ple` builds exactly one of `rows` (I32, table as a tensor) or `embd`
(F32, gathered from disk in `set_input`) — `set_input` asserts it:
`GGML_ASSERT(embd != nullptr && rows == nullptr)`. But `can_reuse()` reads
`rows->ne[0]` unconditionally, so it null-derefs the moment anything decodes.

Nothing calls `can_reuse()` until the first decode, which is why the model always
appears to load fine and then dies — it reads like an I/O or gather fault and isn't.

```
Stack trace of thread 1:
#0  llm_graph_input_ple::can_reuse(llm_graph_params const&) +0x34
```

Fixed by checking whichever tensor exists, taking the count from `ne[0]` for `rows`
and `ne[1]` for `embd` (which is `[ple_head_dim, n_heads*n_tokens]`).

### Verified

`unsloth/Qwen3.8-Flash-Next-GGUF` UD-Q4_K_XL, Vulkan (RADV, Strix Halo gfx1151),
`--ngram-on-disk --ngram-io-threads 64 --ngram-cache 8192 -c 32768`:

- before: aborts at load with the row-index message above
- with fix 1 only: loads, then SIGSEGV on the first decode
- with both: loads in 39 s, 81.4 GiB GTT, the 26.8 GiB `per_layer_token_embd`
  stays on disk, and it generates at 25.6 t/s bare decode

Also reproduced identically on a second quant with a different PLE layout
(`AtomicChat/Qwen3.8-Flash-Next-AD-5.00bpw-Q5_K_M-M64`, one joined table of
320001536 rows), so neither bug is layout- or quant-specific.