### PR TITLE
vulkan: gate the UMA bulk readback on host-cached mappings

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -8677,7 +8677,13 @@ static void ggml_vk_buffer_read_2d(vk_buffer& src, size_t offset, void * dst, si
     // If the device is not an UMA device the memory is host-accessible through rebar. While writing
     // through PCIe is sufficient fast reading back data from PCIe is slower than going through
     // the HW device to host copy path.
-    if(src->memory_property_flags & vk::MemoryPropertyFlagBits::eHostVisible && src->device->uma) {
+    // On UMA a direct CPU read is only fast from a host-cached mapping. A write-combined mapping
+    // (host-visible without HOST_CACHED, which is what amdgpu gives for GTT) reads back at
+    // uncached speed, so bulk reads must use the device copy path. Small reads stay direct to
+    // avoid the fence round trip.
+    const bool host_cached = bool(src->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCached);
+    if((src->memory_property_flags & vk::MemoryPropertyFlagBits::eHostVisible) && src->device->uma &&
+       (host_cached || width * height <= 64 * 1024)) {
         GGML_ASSERT(src->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCoherent);
 
         std::lock_guard<std::recursive_mutex> guard(src->device->mutex);


### PR DESCRIPTION
## Problem

`ggml_vk_buffer_read_2d` takes the direct CPU read path whenever the buffer is host-visible *and* the device is UMA:

```cpp
if (src->memory_property_flags & vk::MemoryPropertyFlagBits::eHostVisible && src->device->uma) {
```

That is only fast from a **host-cached** mapping. A write-combined mapping — host-visible without `HOST_CACHED`, which is what amdgpu hands out for GTT — reads back at uncached speed, so every bulk read crawls.

On this device the UMA buffers really do land on a memory type without `HOST_CACHED`: `ggml_vk_create_buffer_device` asks for `DEVICE_LOCAL | HOST_VISIBLE | HOST_COHERENT` first, and the only `HOST_CACHED` type sits on the host heap. So the condition above is true while the assumption behind it is false.

This also hits `llama-bench`: its depth-context cache round-trips through `llama_state_seq_get_data`, which is this path.

## Change

Gate the direct path on `HOST_CACHED`, and keep reads under 64 KiB direct regardless so small reads do not pay the fence round trip. Everything else falls back to the existing device-to-host copy path, which is what non-UMA devices already use.

## Files

| File | Change |
|---|---|
| `ggml/src/ggml-vulkan/ggml-vulkan.cpp` | `ggml_vk_buffer_read_2d`: add the `HOST_CACHED` / size condition |

7 insertions, 1 deletion.

## Testing

Built from `halo-box/master` + this commit, Release/Vulkan/native on gfx1151 (RADV, Mesa 26.0.8):

```
17410/17410 tests passed
Backend Vulkan0: OK
2/2 backends passed
```

The behaviour change is confined to which of two already-existing read paths is taken; both produce the same bytes.

**Not verified:** other UMA devices (Intel iGPU, Apple, Adreno). On any device whose UMA mapping *is* host-cached the gate simply keeps the current behaviour, since the condition then still holds.

## AI usage

AGENT-AUTHORED. Written by Claude Opus 5 in Claude Code: the diagnosis (memory-type flags on this device), the patch, and this description. Reviewed by me before submitting.
