### PR TITLE
ui: build the embed host tool with flags the host compiler understands

### DIFF
--- a/tools/ui/CMakeLists.txt
+++ b/tools/ui/CMakeLists.txt
@@ -49,10 +49,26 @@ if(CMAKE_CROSSCOMPILING)
         set(LLAMA_UI_EMBED_EXE "${CMAKE_CURRENT_BINARY_DIR}/llama-ui-embed-host")
     endif()
 
+    # The host compiler is not necessarily the one the toolchain file picked. A
+    # Windows toolchain file sets CMAKE_SYSTEM_NAME, which makes CMake treat the
+    # build as cross-compiling even on a Windows host, and HOST_CXX_COMPILER then
+    # resolves to MSVC. MSVC does not take GNU-style flags: it ignores -std=c++17
+    # with only a D9002 warning, drops to C++14, and embed.cpp then fails because
+    # <filesystem> is C++17-only. Pick the spelling the host compiler understands.
+    get_filename_component(HOST_CXX_NAME "${HOST_CXX_COMPILER}" NAME_WE)
+    if(HOST_CXX_NAME STREQUAL "cl")
+        set(LLAMA_UI_EMBED_FLAGS
+            /nologo /O2 /EHsc /std:c++17
+            "/Fo:${CMAKE_CURRENT_BINARY_DIR}/llama-ui-embed-host.obj"
+            "/Fe:${LLAMA_UI_EMBED_EXE}")
+    else()
+        set(LLAMA_UI_EMBED_FLAGS -O2 -std=c++17 -o "${LLAMA_UI_EMBED_EXE}")
+    endif()
+
     add_custom_command(
         OUTPUT  "${LLAMA_UI_EMBED_EXE}"
-        COMMAND "${HOST_CXX_COMPILER}" -O2 -std=c++17
-                -o "${LLAMA_UI_EMBED_EXE}" "${CMAKE_CURRENT_SOURCE_DIR}/embed.cpp"
+        COMMAND "${HOST_CXX_COMPILER}" ${LLAMA_UI_EMBED_FLAGS}
+                "${CMAKE_CURRENT_SOURCE_DIR}/embed.cpp"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/embed.cpp"
         COMMENT "Building llama-ui-embed (host)"
         VERBATIM


### PR DESCRIPTION
## Problem

`llama-ui-embed` is compiled by a custom command with GNU-style flags hardcoded:

```cmake
COMMAND "${HOST_CXX_COMPILER}" -O2 -std=c++17 -o "${LLAMA_UI_EMBED_EXE}" ...
```

That holds as long as the host compiler is `g++` or `clang++`, and breaks the moment it is MSVC:

```
cl.exe -O2 -std=c++17 -o llama-ui-embed-host.exe embed.cpp
cl : Command line warning D9002 : ignoring unknown option '-std=c++17'
warning STL4038: <filesystem> is available only with C++17 or later
embed.cpp(55): error C2039: 'filesystem': is not a member of 'std'
```

MSVC ignores the flag with a warning rather than failing on it, so the compile silently drops to C++14 and then dies on `<filesystem>` 90 lines later — a long way from the cause.

Reaching MSVC here does not need a cross-compile. A Windows toolchain file sets `CMAKE_SYSTEM_NAME`; that alone makes `CMAKE_CROSSCOMPILING` true on a Windows host, and `HOST_CXX_COMPILER` then resolves to `cl.exe` while the target build is clang-cl. Building the server on Windows with `cmake/x64-windows-llvm.cmake` — what upstream's own `windows-cpu` job does — is enough to hit it.

## Change

Select the flag spelling from the host compiler name: `/nologo /O2 /EHsc /std:c++17` with explicit `/Fo:` and `/Fe:` for `cl`, and the existing GNU spelling for everything else. The GNU branch is unchanged.

## Files

| File | Change |
|---|---|
| `tools/ui/CMakeLists.txt` | pick `LLAMA_UI_EMBED_FLAGS` from `HOST_CXX_COMPILER`'s name |

18 insertions, 2 deletions.

## Testing

Configured and built on Linux (g++ host), where the GNU branch is taken and the command line is byte-identical to before.

**Not verified:** the MSVC branch itself — I do not have a Windows box. The flags are the standard MSVC equivalents and the failure they address is reproduced from the error text above, but someone on Windows should confirm the build completes.

## AI usage

AGENT-AUTHORED. Written by Claude Opus 5 in Claude Code, including this description. Reviewed by me before submitting.
