### PR TITLE
vulkan: handle batch sizes > 4 for IQ3_S mat-vec (register spill at NUM_COLS > 4)

### DIFF
--- a/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vec_iq3_s.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vec_iq3_s.comp
@@ -7,7 +7,14 @@ layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
 
 FLOAT_TYPE temp[NUM_COLS][NUM_ROWS];
 
-void calc_superblock(const uint a_offset, const uint b_offset, const uint ib32, const uint i, const uint num_blocks_per_row, const uint first_row, const uint num_rows) {
+// invocations per superblock. with many columns, 8 invocations need too many
+// registers and spill, so use 16 to halve the per-invocation B working set
+const uint TPB = NUM_COLS <= 4 ? 8 : 16;
+const uint NL  = 32 / TPB; // l steps per invocation
+
+void calc_superblock(const uint a_offset, const uint b_offset, const uint itid, const uint i, const uint num_blocks_per_row, const uint first_row, const uint num_rows) {
+    const uint ib32 = itid / (TPB / 8);
+    const uint l0   = (itid % (TPB / 8)) * NL;
     const uint y_idx = i * QUANT_K + 32 * ib32;
 
     uint ibi = a_offset + first_row * num_blocks_per_row + i;
@@ -16,11 +23,8 @@ void calc_superblock(const uint a_offset, const uint b_offset, const uint ib32, 
         const uint scale = (data_a[ibi].scales[ib32/2] >> (4 * (ib32 & 1))) & 0xF;
         const float dscale = d * (1 + 2 * scale);
         const uint qh = data_a[ibi].qh[ib32];
-        FLOAT_TYPE sum[NUM_COLS];
-        [[unroll]] for (uint j = 0; j < NUM_COLS; ++j) {
-            sum[j] = 0.0;
-        }
-        [[unroll]] for (uint l = 0; l < 4; ++l) {
+        [[unroll]] for (uint ll = 0; ll < NL; ++ll) {
+            const uint l = l0 + ll;
             const u8vec2 qs = unpack8(uint32_t(data_a_packed16[ibi].qs[4 * ib32 + l])).xy; // vec4 used due to #12147
             const uint sign = data_a[ibi].signs[4 * ib32 + l];
             const vec4 grid0 = vec4(unpack8(iq3s_grid[qs.x | ((qh << (8 - 2*l)) & 0x100)]));
@@ -30,7 +34,7 @@ void calc_superblock(const uint a_offset, const uint b_offset, const uint ib32, 
                 const vec4 b0 = vec4(data_b_v4[(j*p.batch_stride_b + b_offset + y_idx) / 4 + 2*l + 0]);
                 const vec4 b4 = vec4(data_b_v4[(j*p.batch_stride_b + b_offset + y_idx) / 4 + 2*l + 1]);
 
-                sum[j] =
+                const FLOAT_TYPE sum =
                       fma(FLOAT_TYPE(b0.x), FLOAT_TYPE((sign &   1) != 0 ? -grid0.x : grid0.x),
                       fma(FLOAT_TYPE(b0.y), FLOAT_TYPE((sign &   2) != 0 ? -grid0.y : grid0.y),
                       fma(FLOAT_TYPE(b0.z), FLOAT_TYPE((sign &   4) != 0 ? -grid0.z : grid0.z),
@@ -39,11 +43,10 @@ void calc_superblock(const uint a_offset, const uint b_offset, const uint ib32, 
                       fma(FLOAT_TYPE(b4.y), FLOAT_TYPE((sign &  32) != 0 ? -grid1.y : grid1.y),
                       fma(FLOAT_TYPE(b4.z), FLOAT_TYPE((sign &  64) != 0 ? -grid1.z : grid1.z),
                       fma(FLOAT_TYPE(b4.w), FLOAT_TYPE((sign & 128) != 0 ? -grid1.w : grid1.w),
-                      sum[j]))))))));
+                      FLOAT_TYPE(0.0)))))))));
+
+                temp[j][n] = fma(dscale, sum, temp[j][n]);
             }
-        }
-        [[unroll]] for (uint j = 0; j < NUM_COLS; ++j) {
-            temp[j][n] = fma(dscale, sum[j], temp[j][n]);
         }
         ibi += num_blocks_per_row;
     }
@@ -55,11 +58,11 @@ void compute_outputs(const uint32_t first_row, const uint32_t num_rows) {
 
     const uint num_blocks_per_row = p.ncols / QUANT_K;
 
-    // 8 threads are used to process each block
-    const uint blocks_per_wg = gl_WorkGroupSize.x/8;
+    // TPB invocations are used to process each block
+    const uint blocks_per_wg = gl_WorkGroupSize.x/TPB;
     const uint tid = gl_LocalInvocationID.x;
-    const uint itid = tid % 8;  // 0...7
-    const uint ix = tid / 8;
+    const uint itid = tid % TPB;
+    const uint ix = tid / TPB;
 
     [[unroll]] for (uint j = 0; j < NUM_COLS; ++j) {
         [[unroll]] for (uint i = 0; i < NUM_ROWS; ++i) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9241,6 +9241,10 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
             //test_cases.emplace_back(new test_mul_mat(type_a,    GGML_TYPE_F32, 18,  i, 32*256, { 1,  1}, {8, 1}));
             //test_cases.emplace_back(new test_mul_mat(type_a,    GGML_TYPE_F32, 19,  i, 33*256, { 1,  1}, {1, 1}));
         }
+        // mat-vec shaders split k across lanes and loop over the blocks in strides. k must be
+        // long enough that the loop wraps, else the stride is never exercised
+        test_cases.emplace_back(new test_mul_mat(type_a,    GGML_TYPE_F32, 16,  1, 16*256, { 1,  1}, {1, 1}));
+        test_cases.emplace_back(new test_mul_mat(type_a,    GGML_TYPE_F32, 16,  8, 16*256, { 1,  1}, {1, 1}));
     }
 
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_0, GGML_TYPE_F32, 2880, 32, 2880, {1, 1}, {1, 1}));


### PR DESCRIPTION
## Problem

`mul_mat_vec_iq3_s.comp` assigns 8 invocations per 256-weight superblock, so each invocation keeps 32 floats of B live *per column*. At `NUM_COLS = 8` that overflows the 256-VGPR budget: the shader spills **442 registers into 17 KB of scratch per wave**, making it ~9x slower at `NUM_COLS = 8` than at 4 while doing only 2x the work.

iq3_s is the only quant type that does this. Only batch sizes 5-8 are affected, so single-token generation never hits it — which is why it went unnoticed. **Speculative decoding lives exactly in that range.**

## Change

Use 16 invocations per superblock when `NUM_COLS > 4`, halving the per-invocation B working set. `NUM_COLS` is a specialization constant, so the choice is made at shader compile time and the lane mapping at `NUM_COLS <= 4` is unchanged. This matches how `iq3_xxs` is already structured.

The accumulation is restructured to fold `dscale` inside the `l` loop rather than keeping a `sum[NUM_COLS]` array live across it — that array is the working set that was spilling. Arithmetic at `NUM_COLS <= 4` is therefore not quite bit-identical (same terms, different grouping).

**Second commit — a test-coverage gap this exposed.** Every quant case in `make_test_cases_eval` uses `k=256`, i.e. exactly one superblock per row, so the mat-vec stride loop `for (i = ix; i < num_blocks_per_row; i += blocks_per_wg)` is **never exercised on any backend**. Added two cases per type at `k=16*256` (n=1 and n=8).

The trap when writing that test: `k` must exceed `blocks_per_wg` blocks or it proves nothing. At `k=4*256` a deliberately broken `blocks_per_wg` still passes, because 4 blocks with a stride of 8 visits each block exactly once anyway. `blocks_per_wg` is 4 on the subgroup path but 8 on the NVIDIA/Intel large-workgroup path, so 16 blocks is the safe size.

## Files

| File | Change |
|---|---|
| `ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vec_iq3_s.comp` | `TPB`/`NL` lane split; fold `dscale` into the `l` loop |
| `tests/test-backend-ops.cpp` | 2 mat-vec cases per quant type at `k=16*256` |

22 insertions, 15 deletions.

## Measurements

```
Device:   Radeon 8060S / Ryzen AI MAX+ 395 (gfx1151, RDNA 3.5), wave64
Backend:  Vulkan RADV, Mesa 26.0.3
```

| metric | before | after |
|---|---|---|
| MUL_MAT op, n=8 | 1589 us | 288 us |
| pp8 | 67.6 t/s | 77.0 t/s |
| DFlash2 spec decode, end to end | 33 t/s | 37 t/s |

`RADV_DEBUG=shaderstats,nocache` confirms the mechanism: 442 spilled VGPRs / 17 KB scratch before, none after.

**One-line alternatives were measured and both lose.** Deleting `[[unroll]]` on the `l` loop changes nothing (ACO unrolls a known trip count of 4 regardless): still 459 spilled, 1348 us. `[[dont_unroll]]` does remove the spill entirely (96 VGPRs, 0 spilled) but lands at 1219 us vs this change's 228 us — at 96 VGPRs there is not enough work in flight to hide memory latency. The axis is how much B stays live, not spill-vs-no-spill.

## Testing

Built from `halo-box/master` + these commits, Release/Vulkan/native on gfx1151 (RADV, Mesa 26.0.8):

```
test-backend-ops -o MUL_MAT   1063/1063 tests passed
Backend Vulkan0: OK
```

The count is 1063 here against 1009 for the same build dir without the second commit — i.e. the 54 added cases (2 per quant type) did run, rather than being silently filtered out.

## Related

Also open upstream as [ggml-org/llama.cpp#27449](https://github.com/ggml-org/llama.cpp/pull/27449), unreviewed since 2026-08-20.

**Not verified:** no model on this machine carries IQ3_S tensors any more, so the perplexity check `CONTRIBUTING.md` asks for has not been run. Correctness rests on `test-backend-ops` — including the new `k=16*256` cases, which are what actually cover the changed lane mapping.

## AI usage

AGENT-AUTHORED. Claude Opus 5 in Claude Code found the spill with `RADV_DEBUG=shaderstats`, wrote the fix and the test cases, and wrote this description. Reviewed by me before submitting.
